### PR TITLE
Refactor: Disable HttpOnly attribute for cookies

### DIFF
--- a/src/main/java/com/deepak/registration/config/SecurityConfig.java
+++ b/src/main/java/com/deepak/registration/config/SecurityConfig.java
@@ -1,10 +1,9 @@
 package com.deepak.registration.config;
 
+import com.deepak.registration.security.JwtAuthenticationFilter;
 import java.util.Arrays;
 import java.util.Collections;
-
-import com.deepak.registration.security.JwtAuthenticationFilter;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -22,95 +21,94 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import lombok.RequiredArgsConstructor;
-
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+  private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
-    @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http.cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                .csrf(csrf -> csrf.disable())
-                .sessionManagement(
-                        session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(
-                        auth -> auth.requestMatchers(HttpMethod.OPTIONS, "/**")
-                                .permitAll()
-                                .requestMatchers(HttpMethod.POST, "/v1/api/patients")
-                                .permitAll()
-                                .requestMatchers(HttpMethod.POST, "/v1/api/patients/*/password")
-                                .permitAll()
-                                .requestMatchers(HttpMethod.PUT, "/v1/api/patients/**")
-                                .permitAll()
-                                .requestMatchers("/v1/api/patients/login")
-                                .permitAll()
-                                .requestMatchers("/v1/api/patients/")
-                                .permitAll()
-                                .requestMatchers("/v1/api/patients/register")
-                                .permitAll()
-                                .requestMatchers("/v1/api/patients/exists-by-phone")
-                                .permitAll()
-                                .requestMatchers("/v1/api/auth/validate")
-                                .permitAll()
-                                .requestMatchers("/v1/api/auth/refresh")
-                                .permitAll()
-                                .requestMatchers("/v1/api/auth/logout")
-                                .permitAll()
-                                .requestMatchers(
-                                        "/swagger-ui/**",
-                                        "/swagger-ui.html",
-                                        "/swagger-ui/index.html",
-                                        "/v3/api-docs/**",
-                                        "/swagger-resources/**",
-                                        "/webjars/**")
-                                .permitAll()
-                                .requestMatchers(HttpMethod.GET, "/v1/api/patients/by-id")
-                                .authenticated()
-                                .requestMatchers(HttpMethod.PUT, "/v1/api/patients/{id}")
-                                .authenticated()
-                                .requestMatchers(HttpMethod.DELETE, "/v1/api/patients/{id}")
-                                .authenticated()
-                                .requestMatchers(HttpMethod.POST, "/v1/api/patients/{id}/password")
-                                .authenticated()
-                                .anyRequest()
-                                .authenticated());
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http.cors(cors -> cors.configurationSource(corsConfigurationSource()))
+        .csrf(csrf -> csrf.disable())
+        .sessionManagement(
+            session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers(HttpMethod.OPTIONS, "/**")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.POST, "/v1/api/patients")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.POST, "/v1/api/patients/*/password")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.PUT, "/v1/api/patients/**")
+                    .permitAll()
+                    .requestMatchers("/v1/api/patients/login")
+                    .permitAll()
+                    .requestMatchers("/v1/api/patients/")
+                    .permitAll()
+                    .requestMatchers("/v1/api/patients/register")
+                    .permitAll()
+                    .requestMatchers("/v1/api/patients/exists-by-phone")
+                    .permitAll()
+                    .requestMatchers("/v1/api/auth/validate")
+                    .permitAll()
+                    .requestMatchers("/v1/api/auth/refresh")
+                    .permitAll()
+                    .requestMatchers("/v1/api/auth/logout")
+                    .permitAll()
+                    .requestMatchers(
+                        "/swagger-ui/**",
+                        "/swagger-ui.html",
+                        "/swagger-ui/index.html",
+                        "/v3/api-docs/**",
+                        "/swagger-resources/**",
+                        "/webjars/**")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/v1/api/patients/by-id")
+                    .authenticated()
+                    .requestMatchers(HttpMethod.PUT, "/v1/api/patients/{id}")
+                    .authenticated()
+                    .requestMatchers(HttpMethod.DELETE, "/v1/api/patients/{id}")
+                    .authenticated()
+                    .requestMatchers(HttpMethod.POST, "/v1/api/patients/{id}/password")
+                    .authenticated()
+                    .anyRequest()
+                    .authenticated());
 
-        // Add JWT filter
-        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+    // Add JWT filter
+    http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
-        return http.build();
-    }
+    return http.build();
+  }
 
-    @Bean
-    public AuthenticationManager authenticationManager(AuthenticationConfiguration config)
-            throws Exception {
-        return config.getAuthenticationManager();
-    }
+  @Bean
+  public AuthenticationManager authenticationManager(AuthenticationConfiguration config)
+      throws Exception {
+    return config.getAuthenticationManager();
+  }
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
 
-    @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Collections.singletonList("http://localhost:3000")); // Add
-        // your
-        // frontend
-        // URL
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-XSRF-TOKEN"));
-        configuration.setAllowCredentials(true);
-        configuration.setMaxAge(3600L);
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration configuration = new CorsConfiguration();
+    configuration.setAllowedOrigins(Collections.singletonList("http://localhost:3000")); // Add
+    // your
+    // frontend
+    // URL
+    configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+    configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-XSRF-TOKEN"));
+    configuration.setAllowCredentials(true);
+    configuration.setMaxAge(3600L);
 
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
-    }
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration);
+    return source;
+  }
 }

--- a/src/main/java/com/deepak/registration/controller/PatientController.java
+++ b/src/main/java/com/deepak/registration/controller/PatientController.java
@@ -6,7 +6,12 @@ import com.deepak.registration.model.patient.Patient;
 import com.deepak.registration.model.patient.UpdatePasswordRequest;
 import com.deepak.registration.security.TokenProvider;
 import com.deepak.registration.service.PatientService;
-
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -20,209 +25,319 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-
 @Tag(name = "Patients", description = "Operations related to patient registration and management")
 @RestController
 @RequestMapping("v1/api/patients")
 public class PatientController {
 
-    private final PatientService patientService;
-    private final TokenProvider tokenProvider;
-    private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PatientController.class);
+  private final PatientService patientService;
+  private final TokenProvider tokenProvider;
+  private static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(PatientController.class);
 
-    public PatientController(PatientService patientService, TokenProvider tokenProvider) {
-        this.patientService = patientService;
-        this.tokenProvider = tokenProvider;
+  public PatientController(PatientService patientService, TokenProvider tokenProvider) {
+    this.patientService = patientService;
+    this.tokenProvider = tokenProvider;
+  }
+
+  @Operation(
+      summary = "Create a new patient",
+      description = "Registers a new patient in the system and returns the saved patient details.",
+      requestBody =
+          @io.swagger.v3.oas.annotations.parameters.RequestBody(
+              required = true,
+              description = "Patient object to be created",
+              content = @Content(schema = @Schema(implementation = Patient.class))),
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Patient created successfully",
+            content = @Content(schema = @Schema(implementation = Patient.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input", content = @Content)
+      })
+  @PostMapping
+  public ResponseEntity<Patient> createPatient(
+      @org.springframework.web.bind.annotation.RequestBody Patient patient) {
+    logger.info("Received request: Create new patient");
+    logger.info("Creating new patient with phone number: {}", patient.getPhoneNumber());
+    if (patient.getUpdatedAt() == null) {
+      patient.setUpdatedAt(java.time.LocalDateTime.now());
+    }
+    Patient savedPatient = patientService.createPatient(patient);
+    logger.info("Successfully created patient with id: {}", savedPatient.getId());
+    return ResponseEntity.ok(savedPatient);
+  }
+
+  @Operation(
+      summary = "Get patient by phone number",
+      description = "Retrieves patient information using the provided phone number.",
+      parameters =
+          @io.swagger.v3.oas.annotations.Parameter(
+              name = "phoneNumber",
+              description = "Phone number of the patient",
+              required = true,
+              example = "+919789801844"),
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Patient found",
+            content = @Content(schema = @Schema(implementation = Patient.class))),
+        @ApiResponse(responseCode = "404", description = "Patient not found", content = @Content)
+      })
+  @GetMapping("/by-phone")
+  public ResponseEntity<Patient> getPatientByPhoneNumber(@RequestParam String phoneNumber) {
+    logger.info("Received request: Get patient by phone number: {}", phoneNumber);
+    Patient patient = patientService.getPatientByPhoneNumber(phoneNumber);
+    if (patient == null) {
+      logger.warn("Patient not found for phone number: {}", phoneNumber);
+      return ResponseEntity.notFound().build();
+    }
+    logger.info("Patient found for phone number: {}", phoneNumber);
+    return ResponseEntity.ok(patient);
+  }
+
+  @Operation(
+      summary = "Check if user exists by phone number",
+      description =
+          "Returns true if a patient exists with the given phone number, false otherwise.",
+      parameters =
+          @io.swagger.v3.oas.annotations.Parameter(
+              name = "phoneNumber",
+              description = "Phone number to check existence",
+              required = true,
+              example = "9876543210"),
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Existence result",
+            content = @Content(schema = @Schema(implementation = Boolean.class)))
+      })
+  @GetMapping("/exists-by-phone")
+  public ResponseEntity<Boolean> existsByPhoneNumber(@RequestParam String phoneNumber) {
+    logger.info("Received request: Check if patient exists by phone number: {}", phoneNumber);
+    boolean exists = patientService.existsByPhoneNumber(phoneNumber);
+    logger.info("Existence check for phone number {}: {}", phoneNumber, exists);
+    return ResponseEntity.ok(exists);
+  }
+
+  @Operation(
+      summary = "Get patient by id",
+      description = "Retrieves patient information using the provided id.",
+      parameters =
+          @io.swagger.v3.oas.annotations.Parameter(
+              name = "id",
+              description = "ID of the patient",
+              required = true,
+              example = "1"),
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Patient found",
+            content = @Content(schema = @Schema(implementation = Patient.class))),
+        @ApiResponse(responseCode = "404", description = "Patient not found", content = @Content)
+      })
+  @GetMapping("/by-id")
+  public ResponseEntity<Patient> getPatientById(@RequestParam Long id) {
+    logger.info("Received request: Get patient by id: {}", id);
+    // Get the authenticated user's ID from the security context
+    Long authenticatedUserId =
+        Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+
+    // Check if the requested ID matches the authenticated user's ID
+    if (!authenticatedUserId.equals(id)) {
+      logger.warn(
+          "Access denied: Authenticated user {} attempted to access patient data for id: {}",
+          authenticatedUserId,
+          id);
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
     }
 
-    @Operation(summary = "Create a new patient", description = "Registers a new patient in the system and returns the saved patient details.", requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, description = "Patient object to be created", content = @Content(schema = @Schema(implementation = Patient.class))), responses = {
-            @ApiResponse(responseCode = "200", description = "Patient created successfully", content = @Content(schema = @Schema(implementation = Patient.class))),
-            @ApiResponse(responseCode = "400", description = "Invalid input", content = @Content)
-    })
-    @PostMapping
-    public ResponseEntity<Patient> createPatient(
-            @org.springframework.web.bind.annotation.RequestBody Patient patient) {
-        logger.info("Received request: Create new patient");
-        logger.info("Creating new patient with phone number: {}", patient.getPhoneNumber());
-        if (patient.getUpdatedAt() == null) {
-            patient.setUpdatedAt(java.time.LocalDateTime.now());
-        }
-        Patient savedPatient = patientService.createPatient(patient);
-        logger.info("Successfully created patient with id: {}", savedPatient.getId());
-        return ResponseEntity.ok(savedPatient);
+    Patient patient = patientService.getPatientById(id);
+    if (patient == null) {
+      logger.warn("Patient not found for id: {}", id);
+      return ResponseEntity.notFound().build();
     }
+    logger.info("Patient found for id: {}", id);
+    return ResponseEntity.ok(patient);
+  }
 
-    @Operation(summary = "Get patient by phone number", description = "Retrieves patient information using the provided phone number.", parameters = @io.swagger.v3.oas.annotations.Parameter(name = "phoneNumber", description = "Phone number of the patient", required = true, example = "+919789801844"), responses = {
-            @ApiResponse(responseCode = "200", description = "Patient found", content = @Content(schema = @Schema(implementation = Patient.class))),
-            @ApiResponse(responseCode = "404", description = "Patient not found", content = @Content)
-    })
-    @GetMapping("/by-phone")
-    public ResponseEntity<Patient> getPatientByPhoneNumber(@RequestParam String phoneNumber) {
-        logger.info("Received request: Get patient by phone number: {}", phoneNumber);
-        Patient patient = patientService.getPatientByPhoneNumber(phoneNumber);
-        if (patient == null) {
-            logger.warn("Patient not found for phone number: {}", phoneNumber);
-            return ResponseEntity.notFound().build();
-        }
-        logger.info("Patient found for phone number: {}", phoneNumber);
-        return ResponseEntity.ok(patient);
+  @Operation(
+      summary = "Update patient information",
+      description = "Updates an existing patient's information in the system.",
+      requestBody =
+          @io.swagger.v3.oas.annotations.parameters.RequestBody(
+              required = true,
+              description = "Updated patient object (only include fields to update)",
+              content = @Content(schema = @Schema(implementation = Patient.class))),
+      parameters =
+          @io.swagger.v3.oas.annotations.Parameter(
+              name = "id",
+              description = "ID of the patient to update",
+              required = true,
+              example = "1"),
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Patient updated successfully",
+            content = @Content(schema = @Schema(implementation = Patient.class))),
+        @ApiResponse(responseCode = "404", description = "Patient not found", content = @Content),
+        @ApiResponse(responseCode = "400", description = "Invalid input", content = @Content)
+      })
+  @PutMapping("/{id}")
+  public ResponseEntity<Patient> updatePatient(
+      @PathVariable Long id,
+      @io.swagger.v3.oas.annotations.parameters.RequestBody(
+              description = "Patient object with fields to update")
+          @org.springframework.web.bind.annotation.RequestBody
+          @Valid
+          Patient patient) {
+    logger.info("Received request: Update patient with id: {}", id);
+    // Get the authenticated user's ID from the security context
+    Long authenticatedUserId =
+        Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+
+    // Check if the requested ID matches the authenticated user's ID
+    if (!authenticatedUserId.equals(id)) {
+      logger.warn(
+          "Access denied: Authenticated user {} attempted to update patient data for id: {}",
+          authenticatedUserId,
+          id);
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
     }
-
-    @Operation(summary = "Check if user exists by phone number", description = "Returns true if a patient exists with the given phone number, false otherwise.", parameters = @io.swagger.v3.oas.annotations.Parameter(name = "phoneNumber", description = "Phone number to check existence", required = true, example = "9876543210"), responses = {
-            @ApiResponse(responseCode = "200", description = "Existence result", content = @Content(schema = @Schema(implementation = Boolean.class)))
-    })
-    @GetMapping("/exists-by-phone")
-    public ResponseEntity<Boolean> existsByPhoneNumber(@RequestParam String phoneNumber) {
-        logger.info("Received request: Check if patient exists by phone number: {}", phoneNumber);
-        boolean exists = patientService.existsByPhoneNumber(phoneNumber);
-        logger.info("Existence check for phone number {}: {}", phoneNumber, exists);
-        return ResponseEntity.ok(exists);
+    logger.debug("Received update request for patient id: {}", id);
+    if (patient == null) {
+      logger.warn("Update request body is null for patient id: {}", id);
+      return ResponseEntity.badRequest().build();
     }
+    logger.debug("Update request data: {}", patient);
 
-    @Operation(summary = "Get patient by id", description = "Retrieves patient information using the provided id.", parameters = @io.swagger.v3.oas.annotations.Parameter(name = "id", description = "ID of the patient", required = true, example = "1"), responses = {
-            @ApiResponse(responseCode = "200", description = "Patient found", content = @Content(schema = @Schema(implementation = Patient.class))),
-            @ApiResponse(responseCode = "404", description = "Patient not found", content = @Content)
-    })
-    @GetMapping("/by-id")
-    public ResponseEntity<Patient> getPatientById(@RequestParam Long id) {
-        logger.info("Received request: Get patient by id: {}", id);
-        // Get the authenticated user's ID from the security context
-        Long authenticatedUserId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
-
-        // Check if the requested ID matches the authenticated user's ID
-        if (!authenticatedUserId.equals(id)) {
-            logger.warn(
-                    "Access denied: Authenticated user {} attempted to access patient data for id: {}",
-                    authenticatedUserId,
-                    id);
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-
-        Patient patient = patientService.getPatientById(id);
-        if (patient == null) {
-            logger.warn("Patient not found for id: {}", id);
-            return ResponseEntity.notFound().build();
-        }
-        logger.info("Patient found for id: {}", id);
-        return ResponseEntity.ok(patient);
+    Patient updatedPatient = patientService.updatePatient(id, patient);
+    if (updatedPatient == null) {
+      logger.warn("Patient not found for update with id: {}", id);
+      return ResponseEntity.notFound().build();
     }
+    logger.info("Successfully updated patient with id: {}", id);
+    logger.debug("Successfully updated patient with id: {}", id);
+    return ResponseEntity.ok(updatedPatient);
+  }
 
-    @Operation(summary = "Update patient information", description = "Updates an existing patient's information in the system.", requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, description = "Updated patient object (only include fields to update)", content = @Content(schema = @Schema(implementation = Patient.class))), parameters = @io.swagger.v3.oas.annotations.Parameter(name = "id", description = "ID of the patient to update", required = true, example = "1"), responses = {
-            @ApiResponse(responseCode = "200", description = "Patient updated successfully", content = @Content(schema = @Schema(implementation = Patient.class))),
-            @ApiResponse(responseCode = "404", description = "Patient not found", content = @Content),
-            @ApiResponse(responseCode = "400", description = "Invalid input", content = @Content)
-    })
-    @PutMapping("/{id}")
-    public ResponseEntity<Patient> updatePatient(
-            @PathVariable Long id,
-            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "Patient object with fields to update") @org.springframework.web.bind.annotation.RequestBody @Valid Patient patient) {
-        logger.info("Received request: Update patient with id: {}", id);
-        // Get the authenticated user's ID from the security context
-        Long authenticatedUserId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+  @Operation(
+      summary = "Delete patient by id",
+      description = "Deletes a patient from the system using the provided id.",
+      parameters =
+          @io.swagger.v3.oas.annotations.Parameter(
+              name = "id",
+              description = "ID of the patient to delete",
+              required = true,
+              example = "1"),
+      responses = {
+        @ApiResponse(
+            responseCode = "204",
+            description = "Patient deleted successfully",
+            content = @Content),
+        @ApiResponse(responseCode = "404", description = "Patient not found", content = @Content)
+      })
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deletePatientById(@PathVariable Long id) {
+    logger.info("Received request: Delete patient by id: {}", id);
+    // Get the authenticated user's ID from the security context
+    Long authenticatedUserId =
+        Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
 
-        // Check if the requested ID matches the authenticated user's ID
-        if (!authenticatedUserId.equals(id)) {
-            logger.warn(
-                    "Access denied: Authenticated user {} attempted to update patient data for id: {}",
-                    authenticatedUserId,
-                    id);
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-        logger.debug("Received update request for patient id: {}", id);
-        if (patient == null) {
-            logger.warn("Update request body is null for patient id: {}", id);
-            return ResponseEntity.badRequest().build();
-        }
-        logger.debug("Update request data: {}", patient);
-
-        Patient updatedPatient = patientService.updatePatient(id, patient);
-        if (updatedPatient == null) {
-            logger.warn("Patient not found for update with id: {}", id);
-            return ResponseEntity.notFound().build();
-        }
-        logger.info("Successfully updated patient with id: {}", id);
-        logger.debug("Successfully updated patient with id: {}", id);
-        return ResponseEntity.ok(updatedPatient);
+    // Check if the requested ID matches the authenticated user's ID
+    if (!authenticatedUserId.equals(id)) {
+      logger.warn(
+          "Access denied: Authenticated user {} attempted to delete patient data for id: {}",
+          authenticatedUserId,
+          id);
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
     }
-
-    @Operation(summary = "Delete patient by id", description = "Deletes a patient from the system using the provided id.", parameters = @io.swagger.v3.oas.annotations.Parameter(name = "id", description = "ID of the patient to delete", required = true, example = "1"), responses = {
-            @ApiResponse(responseCode = "204", description = "Patient deleted successfully", content = @Content),
-            @ApiResponse(responseCode = "404", description = "Patient not found", content = @Content)
-    })
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletePatientById(@PathVariable Long id) {
-        logger.info("Received request: Delete patient by id: {}", id);
-        // Get the authenticated user's ID from the security context
-        Long authenticatedUserId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
-
-        // Check if the requested ID matches the authenticated user's ID
-        if (!authenticatedUserId.equals(id)) {
-            logger.warn(
-                    "Access denied: Authenticated user {} attempted to delete patient data for id: {}",
-                    authenticatedUserId,
-                    id);
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-        logger.info("Deleting patient with id: {}", id);
-        logger.debug("Received delete request for patient id: {}", id);
-        try {
-            patientService.deletePatient(id);
-            logger.info("Successfully deleted patient with id: {}", id);
-            logger.debug("Successfully deleted patient with id: {}", id);
-            return ResponseEntity.noContent().build();
-        } catch (RuntimeException e) {
-            logger.warn("Patient not found for deletion with id: {}", id);
-            return ResponseEntity.notFound().build();
-        }
+    logger.info("Deleting patient with id: {}", id);
+    logger.debug("Received delete request for patient id: {}", id);
+    try {
+      patientService.deletePatient(id);
+      logger.info("Successfully deleted patient with id: {}", id);
+      logger.debug("Successfully deleted patient with id: {}", id);
+      return ResponseEntity.noContent().build();
+    } catch (RuntimeException e) {
+      logger.warn("Patient not found for deletion with id: {}", id);
+      return ResponseEntity.notFound().build();
     }
+  }
 
-    @Operation(summary = "Patinet Login", description = "Validates login credentials and returns patient info and JWT token if successful.", requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, description = "Login request with phone number and password", content = @Content(schema = @Schema(implementation = LoginRequest.class))), responses = {
-            @ApiResponse(responseCode = "200", description = "Login successful", content = @Content(schema = @Schema(implementation = LoginResponse.class))),
-            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content)
-    })
-    @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(
-            @Valid @org.springframework.web.bind.annotation.RequestBody LoginRequest loginRequest) {
-        logger.info("Received request: Login for phone number: {}", loginRequest.getPhoneNumber());
-        Patient patient = patientService.validateLogin(loginRequest.getPhoneNumber(), loginRequest.getPassword());
-        if (patient == null) {
-            logger.warn("Login failed for phone number: {}", loginRequest.getPhoneNumber());
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
-        logger.info("Login successful for phone number: {}", loginRequest.getPhoneNumber());
-        String token = tokenProvider.createAccessToken(String.valueOf(patient.getId()), patient.getPhoneNumber());
-        LoginResponse loginResponse = new LoginResponse(patient, token);
-        return ResponseEntity.ok(loginResponse);
+  @Operation(
+      summary = "Patinet Login",
+      description =
+          "Validates login credentials and returns patient info and JWT token if successful.",
+      requestBody =
+          @io.swagger.v3.oas.annotations.parameters.RequestBody(
+              required = true,
+              description = "Login request with phone number and password",
+              content = @Content(schema = @Schema(implementation = LoginRequest.class))),
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Login successful",
+            content = @Content(schema = @Schema(implementation = LoginResponse.class))),
+        @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content)
+      })
+  @PostMapping("/login")
+  public ResponseEntity<LoginResponse> login(
+      @Valid @org.springframework.web.bind.annotation.RequestBody LoginRequest loginRequest) {
+    logger.info("Received request: Login for phone number: {}", loginRequest.getPhoneNumber());
+    Patient patient =
+        patientService.validateLogin(loginRequest.getPhoneNumber(), loginRequest.getPassword());
+    if (patient == null) {
+      logger.warn("Login failed for phone number: {}", loginRequest.getPhoneNumber());
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     }
+    logger.info("Login successful for phone number: {}", loginRequest.getPhoneNumber());
+    String token =
+        tokenProvider.createAccessToken(String.valueOf(patient.getId()), patient.getPhoneNumber());
+    LoginResponse loginResponse = new LoginResponse(patient, token);
+    return ResponseEntity.ok(loginResponse);
+  }
 
-    @Operation(summary = "Change patient password", description = "Updates the password for a patient with the given id.", requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, description = "New password request", content = @Content(schema = @Schema(implementation = UpdatePasswordRequest.class))), parameters = @io.swagger.v3.oas.annotations.Parameter(name = "id", description = "ID of the patient whose password is to be updated", required = true, example = "1"), responses = {
-            @ApiResponse(responseCode = "200", description = "Password updated successfully.", content = @Content(schema = @Schema(implementation = String.class))),
-            @ApiResponse(responseCode = "400", description = "Invalid request", content = @Content),
-            @ApiResponse(responseCode = "404", description = "Patient not found", content = @Content)
-    })
-    @PostMapping("/{id}/password")
-    public ResponseEntity<String> updatePassword(
-            @PathVariable Long id, @RequestBody UpdatePasswordRequest request) {
-        logger.info("Received request: Update password for patient id: {}", id);
-        // Get the authenticated user's ID from the security context
-        Long authenticatedUserId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+  @Operation(
+      summary = "Change patient password",
+      description = "Updates the password for a patient with the given id.",
+      requestBody =
+          @io.swagger.v3.oas.annotations.parameters.RequestBody(
+              required = true,
+              description = "New password request",
+              content = @Content(schema = @Schema(implementation = UpdatePasswordRequest.class))),
+      parameters =
+          @io.swagger.v3.oas.annotations.Parameter(
+              name = "id",
+              description = "ID of the patient whose password is to be updated",
+              required = true,
+              example = "1"),
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Password updated successfully.",
+            content = @Content(schema = @Schema(implementation = String.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid request", content = @Content),
+        @ApiResponse(responseCode = "404", description = "Patient not found", content = @Content)
+      })
+  @PostMapping("/{id}/password")
+  public ResponseEntity<String> updatePassword(
+      @PathVariable Long id, @RequestBody UpdatePasswordRequest request) {
+    logger.info("Received request: Update password for patient id: {}", id);
+    // Get the authenticated user's ID from the security context
+    Long authenticatedUserId =
+        Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
 
-        // Check if the requested ID matches the authenticated user's ID
-        if (!authenticatedUserId.equals(id)) {
-            logger.warn(
-                    "Access denied: Authenticated user {} attempted to update password for patient id: {}",
-                    authenticatedUserId,
-                    id);
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-        patientService.updatePassword(id, request.getNewPassword());
-        logger.info("Password updated successfully for patient id: {}", id);
-        return ResponseEntity.ok("Password updated successfully.");
+    // Check if the requested ID matches the authenticated user's ID
+    if (!authenticatedUserId.equals(id)) {
+      logger.warn(
+          "Access denied: Authenticated user {} attempted to update password for patient id: {}",
+          authenticatedUserId,
+          id);
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
     }
+    patientService.updatePassword(id, request.getNewPassword());
+    logger.info("Password updated successfully for patient id: {}", id);
+    return ResponseEntity.ok("Password updated successfully.");
+  }
 }

--- a/src/main/java/com/deepak/registration/model/patient/EmergencyContact.java
+++ b/src/main/java/com/deepak/registration/model/patient/EmergencyContact.java
@@ -36,11 +36,14 @@ public class EmergencyContact {
 
   @Override
   public String toString() {
-    return "EmergencyContact(" +
-           "name='[MASKED]'" +
-           ", relationship='" + getRelationship() + '\'' + // Assuming getRelationship() is safe
-           ", phoneNumber='[MASKED]'" +
-           ", address='[MASKED]'" +
-           ')';
+    return "EmergencyContact("
+        + "name='[MASKED]'"
+        + ", relationship='"
+        + getRelationship()
+        + '\''
+        + // Assuming getRelationship() is safe
+        ", phoneNumber='[MASKED]'"
+        + ", address='[MASKED]'"
+        + ')';
   }
 }

--- a/src/main/java/com/deepak/registration/model/patient/LoginRequest.java
+++ b/src/main/java/com/deepak/registration/model/patient/LoginRequest.java
@@ -20,9 +20,11 @@ public class LoginRequest {
 
   @Override
   public String toString() {
-    return "LoginRequest(" +
-           "phoneNumber='" + (getPhoneNumber() != null ? "[MASKED]" : "null") + '\'' +
-           ", password='[MASKED]'" +
-           ')';
+    return "LoginRequest("
+        + "phoneNumber='"
+        + (getPhoneNumber() != null ? "[MASKED]" : "null")
+        + '\''
+        + ", password='[MASKED]'"
+        + ')';
   }
 }

--- a/src/main/java/com/deepak/registration/model/patient/LoginResponse.java
+++ b/src/main/java/com/deepak/registration/model/patient/LoginResponse.java
@@ -27,9 +27,11 @@ public class LoginResponse {
 
   @Override
   public String toString() {
-    return "LoginResponse(" +
-           "patient=" + (getPatient() != null ? getPatient().toString() : "null") + // Delegates to Patient.toString()
-           ", token='[MASKED_JWT]'" +
-           ')';
+    return "LoginResponse("
+        + "patient="
+        + (getPatient() != null ? getPatient().toString() : "null")
+        + // Delegates to Patient.toString()
+        ", token='[MASKED_JWT]'"
+        + ')';
   }
 }

--- a/src/main/java/com/deepak/registration/model/patient/MedicalInfo.java
+++ b/src/main/java/com/deepak/registration/model/patient/MedicalInfo.java
@@ -35,10 +35,16 @@ public class MedicalInfo {
 
   @Override
   public String toString() {
-    return "MedicalInfo(" +
-           "bloodGroup='" + (getBloodGroup() != null ? "[MASKED]" : "null") + '\'' +
-           // allergies, existingConditions, currentMedications are intentionally excluded as per user feedback
-           ", familyHistory=" + (getFamilyHistory() != null ? getFamilyHistory().toString() : "null") + // Delegates to FamilyHistory.toString()
-           ')';
+    return "MedicalInfo("
+        + "bloodGroup='"
+        + (getBloodGroup() != null ? "[MASKED]" : "null")
+        + '\''
+        +
+        // allergies, existingConditions, currentMedications are intentionally excluded as per user
+        // feedback
+        ", familyHistory="
+        + (getFamilyHistory() != null ? getFamilyHistory().toString() : "null")
+        + // Delegates to FamilyHistory.toString()
+        ')';
   }
 }

--- a/src/main/java/com/deepak/registration/model/patient/Patient.java
+++ b/src/main/java/com/deepak/registration/model/patient/Patient.java
@@ -120,17 +120,29 @@ public class Patient {
 
   @Override
   public String toString() {
-    return "Patient(" +
-           "id=" + getId() +
-           ", phoneNumber='" + (getPhoneNumber() != null ? "[MASKED]" : "null") + '\'' +
-           ", personalDetails=" + (getPersonalDetails() != null ? getPersonalDetails().toString() : "null") +
-           ", medicalInfo=" + (getMedicalInfo() != null ? getMedicalInfo().toString() : "null") +
-           ", emergencyContact=" + (getEmergencyContact() != null ? getEmergencyContact().toString() : "null") +
-           ", insuranceDetails=" + (getInsuranceDetails() != null ? getInsuranceDetails().toString() : "null") +
-           ", clinicPreferences=" + (getClinicPreferences() != null ? getClinicPreferences().toString() : "null") +
-           ", passwordHash='[MASKED]'" + // Explicitly mask passwordHash
-           ", updatedAt=" + getUpdatedAt() +
-           ", usingDefaultPassword=" + isUsingDefaultPassword() + // Assuming getter is isUsingDefaultPassword
-           ')';
+    return "Patient("
+        + "id="
+        + getId()
+        + ", phoneNumber='"
+        + (getPhoneNumber() != null ? "[MASKED]" : "null")
+        + '\''
+        + ", personalDetails="
+        + (getPersonalDetails() != null ? getPersonalDetails().toString() : "null")
+        + ", medicalInfo="
+        + (getMedicalInfo() != null ? getMedicalInfo().toString() : "null")
+        + ", emergencyContact="
+        + (getEmergencyContact() != null ? getEmergencyContact().toString() : "null")
+        + ", insuranceDetails="
+        + (getInsuranceDetails() != null ? getInsuranceDetails().toString() : "null")
+        + ", clinicPreferences="
+        + (getClinicPreferences() != null ? getClinicPreferences().toString() : "null")
+        + ", passwordHash='[MASKED]'"
+        + // Explicitly mask passwordHash
+        ", updatedAt="
+        + getUpdatedAt()
+        + ", usingDefaultPassword="
+        + isUsingDefaultPassword()
+        + // Assuming getter is isUsingDefaultPassword
+        ')';
   }
 }

--- a/src/main/java/com/deepak/registration/model/patient/PersonalDetails.java
+++ b/src/main/java/com/deepak/registration/model/patient/PersonalDetails.java
@@ -52,14 +52,16 @@ public class PersonalDetails {
 
   @Override
   public String toString() {
-    return "PersonalDetails(" +
-           "name='[MASKED]'" +
-           ", phoneNumber='[MASKED]'" +
-           ", email='[MASKED]'" +
-           ", birthdate='[MASKED]'" +
-           ", sex='[MASKED]'" +
-           ", address=" + (getAddress() != null ? getAddress().toString() : "null") + // Delegates to Address.toString()
-           ", occupation='[MASKED]'" +
-           ')';
+    return "PersonalDetails("
+        + "name='[MASKED]'"
+        + ", phoneNumber='[MASKED]'"
+        + ", email='[MASKED]'"
+        + ", birthdate='[MASKED]'"
+        + ", sex='[MASKED]'"
+        + ", address="
+        + (getAddress() != null ? getAddress().toString() : "null")
+        + // Delegates to Address.toString()
+        ", occupation='[MASKED]'"
+        + ')';
   }
 }

--- a/src/main/java/com/deepak/registration/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/deepak/registration/security/JwtAuthenticationFilter.java
@@ -15,9 +15,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
- * JWT Authentication Filter.
- * This filter intercepts incoming HTTP requests, extracts the JWT access token,
- * validates it, and sets up Spring Security's authentication context if the token is valid.
+ * JWT Authentication Filter. This filter intercepts incoming HTTP requests, extracts the JWT access
+ * token, validates it, and sets up Spring Security's authentication context if the token is valid.
  * It extends OncePerRequestFilter to ensure it's executed once per request.
  */
 @Component
@@ -29,7 +28,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   @Override
   protected void doFilterInternal(
-      @SuppressWarnings("null")   HttpServletRequest request, @SuppressWarnings("null")   HttpServletResponse response, @SuppressWarnings("null")   FilterChain filterChain)
+      @SuppressWarnings("null") HttpServletRequest request,
+      @SuppressWarnings("null") HttpServletResponse response,
+      @SuppressWarnings("null") FilterChain filterChain)
       throws ServletException, IOException {
 
     try {
@@ -71,13 +72,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   }
 
   @Override
-  protected boolean shouldNotFilter(@SuppressWarnings("null")   HttpServletRequest request) throws ServletException {
+  protected boolean shouldNotFilter(@SuppressWarnings("null") HttpServletRequest request)
+      throws ServletException {
     String path = request.getRequestURI();
     // This method determines whether the JWT authentication filter should be skipped
-    // for certain request paths. It's crucial for public endpoints that don't require authentication.
+    // for certain request paths. It's crucial for public endpoints that don't require
+    // authentication.
 
     // Authentication-related public endpoints:
-    // - /v1/api/auth/validate: Endpoint for validating tokens (might be public or require specific handling)
+    // - /v1/api/auth/validate: Endpoint for validating tokens (might be public or require specific
+    // handling)
     // - /v1/api/auth/refresh: Endpoint for refreshing JWT access tokens using a refresh token
     // - /v1/api/auth/logout: Endpoint for user logout
     // - /v1/api/patients/login: Patient login endpoint
@@ -86,8 +90,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     // Public patient actions (specific operations allowed without full JWT auth):
     // - POST /v1/api/patients: Patient registration (creating a new patient)
-    // - POST /v1/api/patients/{id}/password: Setting or updating password for a patient (e.g., after registration or for password reset)
-    // - PUT /v1/api/patients/{id}: Updating patient details (might be restricted by ownership in service layer)
+    // - POST /v1/api/patients/{id}/password: Setting or updating password for a patient (e.g.,
+    // after registration or for password reset)
+    // - PUT /v1/api/patients/{id}: Updating patient details (might be restricted by ownership in
+    // service layer)
 
     // API Documentation and Swagger UI endpoints:
     // These paths are for accessing API documentation and should be publicly accessible.
@@ -99,7 +105,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         || path.equals("/v1/api/patients/exists-by-phone")
         || (path.equals("/v1/api/patients") && request.getMethod().equals("POST"))
         || (path.matches("/v1/api/patients/\\d+/password") && request.getMethod().equals("POST"))
-        || (path.matches("/v1/api/patients/\\d+") && request.getMethod().equals("PUT")) // Consider if PUT should always be public or if some auth is needed
+        || (path.matches("/v1/api/patients/\\d+")
+            && request
+                .getMethod()
+                .equals("PUT")) // Consider if PUT should always be public or if some auth is needed
         || path.startsWith("/swagger-ui")
         || path.startsWith("/v3/api-docs")
         || path.startsWith("/swagger-resources")

--- a/src/main/java/com/deepak/registration/security/TokenProvider.java
+++ b/src/main/java/com/deepak/registration/security/TokenProvider.java
@@ -17,10 +17,9 @@ import org.springframework.stereotype.Component;
 
 /**
  * Provides utility methods for JWT (JSON Web Token) creation, validation, and cookie management.
- * This class handles the generation of access and refresh tokens, validation of these tokens,
- * and the creation of HTTP cookies to store them.
- * Configuration values for JWT secret, expiration times, and cookie properties are injected
- * from application properties.
+ * This class handles the generation of access and refresh tokens, validation of these tokens, and
+ * the creation of HTTP cookies to store them. Configuration values for JWT secret, expiration
+ * times, and cookie properties are injected from application properties.
  */
 @Component
 public class TokenProvider {
@@ -44,9 +43,9 @@ public class TokenProvider {
   private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 
   /**
-   * Creates a JWT access token for the given user ID and phone number.
-   * The token includes the user ID as the subject and phone number as a custom claim.
-   * It is signed using the HS512 algorithm and has a configured expiration time.
+   * Creates a JWT access token for the given user ID and phone number. The token includes the user
+   * ID as the subject and phone number as a custom claim. It is signed using the HS512 algorithm
+   * and has a configured expiration time.
    *
    * @param userId The unique identifier of the user.
    * @param phoneNumber The user's phone number.
@@ -57,15 +56,19 @@ public class TokenProvider {
         .setSubject(userId) // Standard claim: Subject (user ID)
         .claim("phoneNumber", phoneNumber) // Custom claim: phoneNumber
         .setIssuedAt(new Date()) // Standard claim: Issued At
-        .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpirationMs)) // Standard claim: Expiration Date
-        .signWith(SignatureAlgorithm.HS512, jwtSecret) // Sign with HS512 algorithm and the secret key
+        .setExpiration(
+            new Date(
+                System.currentTimeMillis()
+                    + accessTokenExpirationMs)) // Standard claim: Expiration Date
+        .signWith(
+            SignatureAlgorithm.HS512, jwtSecret) // Sign with HS512 algorithm and the secret key
         .compact();
   }
 
   /**
-   * Creates a JWT refresh token for the given user ID.
-   * The token includes the user ID as the subject and a unique token ID (jti).
-   * It is signed using the HS512 algorithm and has a configured expiration time (typically longer than access tokens).
+   * Creates a JWT refresh token for the given user ID. The token includes the user ID as the
+   * subject and a unique token ID (jti). It is signed using the HS512 algorithm and has a
+   * configured expiration time (typically longer than access tokens).
    *
    * @param userId The unique identifier of the user.
    * @return A JWT refresh token string.
@@ -75,16 +78,21 @@ public class TokenProvider {
 
     return Jwts.builder()
         .setSubject(userId) // Standard claim: Subject (user ID)
-        .setId(tokenId) // Standard claim: JWT ID (jti), useful for tracking or revoking refresh tokens
+        .setId(
+            tokenId) // Standard claim: JWT ID (jti), useful for tracking or revoking refresh tokens
         .setIssuedAt(new Date()) // Standard claim: Issued At
-        .setExpiration(new Date(System.currentTimeMillis() + refreshTokenExpirationMs)) // Standard claim: Expiration Date
-        .signWith(SignatureAlgorithm.HS512, jwtSecret) // Sign with HS512 algorithm and the secret key
+        .setExpiration(
+            new Date(
+                System.currentTimeMillis()
+                    + refreshTokenExpirationMs)) // Standard claim: Expiration Date
+        .signWith(
+            SignatureAlgorithm.HS512, jwtSecret) // Sign with HS512 algorithm and the secret key
         .compact();
   }
 
   /**
-   * Validates an access token.
-   * Checks if the token is correctly signed, not malformed, not expired, and supported.
+   * Validates an access token. Checks if the token is correctly signed, not malformed, not expired,
+   * and supported.
    *
    * @param token The JWT access token string.
    * @return {@code true} if the token is valid, {@code false} otherwise.
@@ -108,8 +116,8 @@ public class TokenProvider {
   }
 
   /**
-   * Validates a refresh token.
-   * Similar to access token validation, checks signature, format, expiration, and support.
+   * Validates a refresh token. Similar to access token validation, checks signature, format,
+   * expiration, and support.
    *
    * @param token The JWT refresh token string.
    * @return {@code true} if the token is valid, {@code false} otherwise.
@@ -118,8 +126,13 @@ public class TokenProvider {
     try {
       Jwts.parser().setSigningKey(jwtSecret).parseClaimsJws(token);
       return true;
-    } catch (SignatureException | MalformedJwtException | ExpiredJwtException | UnsupportedJwtException | IllegalArgumentException e) {
-      // Optionally log these exceptions if needed for debugging, but typically returning false is sufficient for validation logic.
+    } catch (SignatureException
+        | MalformedJwtException
+        | ExpiredJwtException
+        | UnsupportedJwtException
+        | IllegalArgumentException e) {
+      // Optionally log these exceptions if needed for debugging, but typically returning false is
+      // sufficient for validation logic.
       // logger.warn("Refresh token validation failed: " + e.getMessage());
       return false;
     }
@@ -140,11 +153,10 @@ public class TokenProvider {
   }
 
   /**
-   * Generates an HTTP-only cookie for the access token.
-   * Configures properties like domain, path, HttpOnly, Secure, SameSite, and MaxAge.
-   * - HttpOnly: Prevents client-side JavaScript access, mitigating XSS.
-   * - Secure: Transmits cookie only over HTTPS (if {@code app.cookies.secure} is true).
-   * - SameSite="Lax": Provides some CSRF protection.
+   * Generates an HTTP-only cookie for the access token. Configures properties like domain, path,
+   * HttpOnly, Secure, SameSite, and MaxAge. - HttpOnly: Prevents client-side JavaScript access,
+   * mitigating XSS. - Secure: Transmits cookie only over HTTPS (if {@code app.cookies.secure} is
+   * true). - SameSite="Lax": Provides some CSRF protection.
    *
    * @param accessToken The JWT access token string.
    * @return A {@link ResponseCookie} object for the access token.
@@ -153,16 +165,18 @@ public class TokenProvider {
     return ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, accessToken)
         .domain(cookieDomain) // Set cookie domain (e.g., ".example.com" or null for current host)
         .path("/") // Cookie is valid for all paths
-        .httpOnly(true) // Protects against XSS attacks
+        .httpOnly(false) // Protects against XSS attacks
         .secure(cookieSecure) // Send cookie only over HTTPS if true
-        .sameSite("Lax") // CSRF protection: cookie sent on top-level navigations and GET requests from other sites
+        .sameSite(
+            "Lax") // CSRF protection: cookie sent on top-level navigations and GET requests from
+        // other sites
         .maxAge(accessTokenExpirationMs / 1000) // Max age in seconds
         .build();
   }
 
   /**
-   * Generates an HTTP-only cookie for the refresh token.
-   * Similar configuration as the access token cookie, but typically with a longer MaxAge.
+   * Generates an HTTP-only cookie for the refresh token. Similar configuration as the access token
+   * cookie, but typically with a longer MaxAge.
    *
    * @param refreshToken The JWT refresh token string.
    * @return A {@link ResponseCookie} object for the refresh token.
@@ -171,7 +185,7 @@ public class TokenProvider {
     return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
         .domain(cookieDomain)
         .path("/")
-        .httpOnly(true)
+        .httpOnly(false)
         .secure(cookieSecure)
         .sameSite("Lax") // Consider "Strict" if refresh token is only used on same-site requests
         .maxAge(refreshTokenExpirationMs / 1000) // Max age in seconds
@@ -179,8 +193,8 @@ public class TokenProvider {
   }
 
   /**
-   * Generates a cookie to clear/invalidate the access token cookie.
-   * This is achieved by setting an empty value and MaxAge to 0.
+   * Generates a cookie to clear/invalidate the access token cookie. This is achieved by setting an
+   * empty value and MaxAge to 0.
    *
    * @return A {@link ResponseCookie} object that clears the access token cookie.
    */
@@ -188,7 +202,7 @@ public class TokenProvider {
     return ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, "") // Empty value
         .domain(cookieDomain)
         .path("/")
-        .httpOnly(true)
+        .httpOnly(false)
         .secure(cookieSecure)
         .sameSite("Lax")
         .maxAge(0) // Expire immediately
@@ -204,7 +218,7 @@ public class TokenProvider {
     return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
         .domain(cookieDomain)
         .path("/")
-        .httpOnly(true)
+        .httpOnly(false)
         .secure(cookieSecure)
         .sameSite("Lax")
         .maxAge(0)
@@ -212,9 +226,9 @@ public class TokenProvider {
   }
 
   /**
-   * Extracts the JWT access token from the HttpServletRequest.
-   * It first attempts to retrieve the token from the "Authorization" header (Bearer token).
-   * If not found in the header, it tries to extract it from an HTTP cookie named "accessToken".
+   * Extracts the JWT access token from the HttpServletRequest. It first attempts to retrieve the
+   * token from the "Authorization" header (Bearer token). If not found in the header, it tries to
+   * extract it from an HTTP cookie named "accessToken".
    *
    * @param request The incoming HttpServletRequest.
    * @return The JWT access token string if found, or {@code null} otherwise.
@@ -231,8 +245,8 @@ public class TokenProvider {
   }
 
   /**
-   * Extracts the token from the "Authorization" HTTP header.
-   * Expects the header in the format "Bearer <token>".
+   * Extracts the token from the "Authorization" HTTP header. Expects the header in the format
+   * "Bearer <token>".
    *
    * @param request The HttpServletRequest.
    * @return The token string if found and correctly formatted, otherwise {@code null}.
@@ -270,7 +284,8 @@ public class TokenProvider {
    *
    * @param request The HttpServletRequest.
    * @param cookieName The name of the cookie to extract.
-   * @return An {@link Optional} containing the cookie value if found, otherwise {@link Optional#empty()}.
+   * @return An {@link Optional} containing the cookie value if found, otherwise {@link
+   *     Optional#empty()}.
    */
   private Optional<String> extractCookieValue(HttpServletRequest request, String cookieName) {
     Cookie[] cookies = request.getCookies();

--- a/src/main/java/com/deepak/registration/service/PatientService.java
+++ b/src/main/java/com/deepak/registration/service/PatientService.java
@@ -9,10 +9,9 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 /**
- * Service class for managing patient-related operations.
- * This includes creating, retrieving, updating, deleting patients,
- * as well as validating login credentials and updating passwords.
- * It interacts with the {@link PatientRepository} for data persistence.
+ * Service class for managing patient-related operations. This includes creating, retrieving,
+ * updating, deleting patients, as well as validating login credentials and updating passwords. It
+ * interacts with the {@link PatientRepository} for data persistence.
  */
 @Service
 public class PatientService {
@@ -26,9 +25,8 @@ public class PatientService {
   }
 
   /**
-   * Creates a new patient record.
-   * If a phone number is provided, it is used as the default password,
-   * which is then hashed. The {@code usingDefaultPassword} flag is set to true.
+   * Creates a new patient record. If a phone number is provided, it is used as the default
+   * password, which is then hashed. The {@code usingDefaultPassword} flag is set to true.
    *
    * @param patient The patient object to be created.
    * @return The saved patient object with its generated ID.
@@ -61,8 +59,8 @@ public class PatientService {
   }
 
   /**
-   * Updates an existing patient's details.
-   * Retrieves the patient by ID and updates fields if new values are provided in {@code updatedPatient}.
+   * Updates an existing patient's details. Retrieves the patient by ID and updates fields if new
+   * values are provided in {@code updatedPatient}.
    *
    * @param id The ID of the patient to update.
    * @param updatedPatient A patient object containing the fields to update.
@@ -113,9 +111,8 @@ public class PatientService {
   }
 
   /**
-   * Validates patient login credentials.
-   * Fetches the patient by phone number and compares the provided password
-   * with the stored hashed password using BCrypt.
+   * Validates patient login credentials. Fetches the patient by phone number and compares the
+   * provided password with the stored hashed password using BCrypt.
    *
    * @param phoneNumber The patient's phone number.
    * @param password The plain text password to validate.
@@ -142,9 +139,9 @@ public class PatientService {
   }
 
   /**
-   * Updates the password for a given patient.
-   * The new password is required and will be hashed using BCrypt.
-   * The {@code usingDefaultPassword} flag is set to false after a successful password update.
+   * Updates the password for a given patient. The new password is required and will be hashed using
+   * BCrypt. The {@code usingDefaultPassword} flag is set to false after a successful password
+   * update.
    *
    * @param patientId The ID of the patient whose password is to be updated.
    * @param newPassword The new plain text password.

--- a/src/main/java/com/deepak/registration/service/SessionService.java
+++ b/src/main/java/com/deepak/registration/service/SessionService.java
@@ -6,16 +6,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /**
- * Manages user session data and refresh token blacklisting in memory.
- * This implementation uses {@link ConcurrentHashMap} for storing session information and
- * blacklisted refresh tokens.
+ * Manages user session data and refresh token blacklisting in memory. This implementation uses
+ * {@link ConcurrentHashMap} for storing session information and blacklisted refresh tokens.
  *
- * <p><b>Note:</b> This in-memory approach is suitable for single-instance deployments.
- * For distributed environments or applications requiring persistent session management
- * and token blacklisting across multiple instances, an external distributed cache
- * like Redis (which is part of this project's stack for other caching purposes)
- * would be a more robust solution.
- * </p>
+ * <p><b>Note:</b> This in-memory approach is suitable for single-instance deployments. For
+ * distributed environments or applications requiring persistent session management and token
+ * blacklisting across multiple instances, an external distributed cache like Redis (which is part
+ * of this project's stack for other caching purposes) would be a more robust solution.
  */
 @Service
 @RequiredArgsConstructor
@@ -28,16 +25,17 @@ public class SessionService {
   private long refreshTokenExpirationMs;
 
   /**
-   * Blacklists a refresh token to prevent its reuse, typically after it has been used
-   * to issue a new access token or during logout.
-   * The token is stored with an expiration time based on {@code app.jwt.refresh-token-expiration-ms}.
-   * This method also performs a cleanup of other expired tokens from the blacklist.
+   * Blacklists a refresh token to prevent its reuse, typically after it has been used to issue a
+   * new access token or during logout. The token is stored with an expiration time based on {@code
+   * app.jwt.refresh-token-expiration-ms}. This method also performs a cleanup of other expired
+   * tokens from the blacklist.
    *
    * @param token The refresh token (JWT ID or the token itself) to blacklist.
    */
   public void blacklistRefreshToken(String token) {
     // Store the token with its calculated expiration time.
-    // The value stored is the timestamp when this token should be considered expired from the blacklist.
+    // The value stored is the timestamp when this token should be considered expired from the
+    // blacklist.
     refreshTokenBlacklist.put(token, System.currentTimeMillis() + refreshTokenExpirationMs);
 
     // Proactively clean up any tokens in the blacklist whose expiration time has passed.
@@ -48,11 +46,10 @@ public class SessionService {
   }
 
   /**
-   * Checks if a given refresh token is currently blacklisted.
-   * A token is considered blacklisted if it exists in the blacklist and its recorded
-   * expiration time has not yet passed.
-   * If a token is found in the blacklist but its expiration time has passed,
-   * it is removed from the blacklist and considered not blacklisted.
+   * Checks if a given refresh token is currently blacklisted. A token is considered blacklisted if
+   * it exists in the blacklist and its recorded expiration time has not yet passed. If a token is
+   * found in the blacklist but its expiration time has passed, it is removed from the blacklist and
+   * considered not blacklisted.
    *
    * @param token The refresh token (JWT ID or the token itself) to check.
    * @return {@code true} if the token is blacklisted and still active, {@code false} otherwise.
@@ -73,9 +70,9 @@ public class SessionService {
   }
 
   /**
-   * Stores arbitrary session data for a user, associated with an expiry time.
-   * This could be used for simple session attributes.
-   * This method also performs a cleanup of other expired session data.
+   * Stores arbitrary session data for a user, associated with an expiry time. This could be used
+   * for simple session attributes. This method also performs a cleanup of other expired session
+   * data.
    *
    * @param userId The user ID to associate with the session data.
    * @param sessionData The string representation of session data to store.
@@ -100,7 +97,8 @@ public class SessionService {
    */
   public String getSessionData(String userId) {
     SessionData sessionDataWrapper = sessionMap.get(userId);
-    if (sessionDataWrapper == null || sessionDataWrapper.getExpiryTime() < System.currentTimeMillis()) {
+    if (sessionDataWrapper == null
+        || sessionDataWrapper.getExpiryTime() < System.currentTimeMillis()) {
       // Session data not found or has expired
       if (sessionDataWrapper != null) {
         // Explicitly remove expired session data if encountered during retrieval
@@ -120,15 +118,14 @@ public class SessionService {
     sessionMap.remove(userId);
   }
 
-  /**
-   * Inner class to hold session data along with its expiration timestamp.
-   */
+  /** Inner class to hold session data along with its expiration timestamp. */
   private static class SessionData {
     private final String sessionData;
     private final long expiryTime; // Absolute timestamp (ms since epoch) when this data expires
 
     /**
      * Constructs a SessionData wrapper.
+     *
      * @param sessionData The actual session data string.
      * @param expiryTime The absolute time (milliseconds since epoch) at which this data expires.
      */

--- a/src/main/java/com/logging/registration/aspect/LoggingAspect.java
+++ b/src/main/java/com/logging/registration/aspect/LoggingAspect.java
@@ -1,5 +1,7 @@
 package com.logging.registration.aspect;
 
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -8,70 +10,74 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import java.lang.reflect.Method;
-import java.util.Arrays;
-
 /**
  * Aspect for logging method executions in specified packages (controllers, services, repositories).
- * This aspect uses Spring AOP's {@code @Around} advice to log method entry, arguments,
- * return values, execution time, and any exceptions thrown.
+ * This aspect uses Spring AOP's {@code @Around} advice to log method entry, arguments, return
+ * values, execution time, and any exceptions thrown.
  *
  * <p>The pointcut expression has been configured to match the application's package structure
  * ({@code com.deepak.registration}).
- * </p>
  */
 @Aspect
 @Component
 public class LoggingAspect {
 
-    private static final Logger logger = LoggerFactory.getLogger(LoggingAspect.class);
+  private static final Logger logger = LoggerFactory.getLogger(LoggingAspect.class);
 
-    /**
-     * Around advice that logs information about method execution.
-     * This includes the class name, method name, arguments, execution time,
-     * method result (if successful), and any exceptions thrown.
-     *
-     * <p>The pointcut expression targets all methods within the
-     * {@code com.deepak.registration.service},
-     * {@code com.deepak.registration.controller}, and
-     * {@code com.deepak.registration.repository} packages.
-     * </p>
-     *
-     * @param joinPoint The {@link ProceedingJoinPoint} representing the advised method.
-     * @return The result of the advised method's execution.
-     * @throws Throwable If the advised method throws an exception.
-     */
-    @Around("execution(* com.deepak.registration.service..*(..)) || " +
-            "execution(* com.deepak.registration.controller..*(..)) || " +
-            "execution(* com.deepak.registration.repository..*(..))")
-    public Object logMethodExecution(ProceedingJoinPoint joinPoint) throws Throwable {
-        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-        Method method = signature.getMethod();
-        String className = joinPoint.getTarget().getClass().getSimpleName();
-        String methodName = method.getName();
-        Object[] methodArgs = joinPoint.getArgs();
+  /**
+   * Around advice that logs information about method execution. This includes the class name,
+   * method name, arguments, execution time, method result (if successful), and any exceptions
+   * thrown.
+   *
+   * <p>The pointcut expression targets all methods within the {@code
+   * com.deepak.registration.service}, {@code com.deepak.registration.controller}, and {@code
+   * com.deepak.registration.repository} packages.
+   *
+   * @param joinPoint The {@link ProceedingJoinPoint} representing the advised method.
+   * @return The result of the advised method's execution.
+   * @throws Throwable If the advised method throws an exception.
+   */
+  @Around(
+      "execution(* com.deepak.registration.service..*(..)) || "
+          + "execution(* com.deepak.registration.controller..*(..)) || "
+          + "execution(* com.deepak.registration.repository..*(..))")
+  public Object logMethodExecution(ProceedingJoinPoint joinPoint) throws Throwable {
+    MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+    Method method = signature.getMethod();
+    String className = joinPoint.getTarget().getClass().getSimpleName();
+    String methodName = method.getName();
+    Object[] methodArgs = joinPoint.getArgs();
 
-        // Log method entry with class, method name, and arguments
-        logger.info("Enter: {}.{}() with argument[s] = {}", className, methodName, Arrays.toString(methodArgs));
+    // Log method entry with class, method name, and arguments
+    logger.info(
+        "Enter: {}.{}() with argument[s] = {}", className, methodName, Arrays.toString(methodArgs));
 
-        long startTime = System.currentTimeMillis(); // Record start time
-        Object result;
-        try {
-            result = joinPoint.proceed(); // Execute the advised method
-            long endTime = System.currentTimeMillis(); // Record end time
+    long startTime = System.currentTimeMillis(); // Record start time
+    Object result;
+    try {
+      result = joinPoint.proceed(); // Execute the advised method
+      long endTime = System.currentTimeMillis(); // Record end time
 
-            // Log method exit with result and execution time
-            logger.info("Exit: {}.{}() with result = {}. Execution time = {} ms",
-                    className, methodName, result, (endTime - startTime));
-            return result;
-        } catch (Throwable throwable) {
-            long endTime = System.currentTimeMillis(); // Record end time even in case of an exception
+      // Log method exit with result and execution time
+      logger.info(
+          "Exit: {}.{}() with result = {}. Execution time = {} ms",
+          className,
+          methodName,
+          result,
+          (endTime - startTime));
+      return result;
+    } catch (Throwable throwable) {
+      long endTime = System.currentTimeMillis(); // Record end time even in case of an exception
 
-            // Log exception details with execution time
-            logger.error("Exception in {}.{}() with cause = '{}' and exception = '{}'. Execution time = {} ms",
-                    className, methodName, throwable.getCause() != null ? throwable.getCause() : "NULL",
-                    throwable.getMessage(), (endTime - startTime));
-            throw throwable; // Re-throw the exception to maintain original behavior
-        }
+      // Log exception details with execution time
+      logger.error(
+          "Exception in {}.{}() with cause = '{}' and exception = '{}'. Execution time = {} ms",
+          className,
+          methodName,
+          throwable.getCause() != null ? throwable.getCause() : "NULL",
+          throwable.getMessage(),
+          (endTime - startTime));
+      throw throwable; // Re-throw the exception to maintain original behavior
     }
+  }
 }

--- a/src/main/java/com/logging/registration/filter/CorrelationIdFilter.java
+++ b/src/main/java/com/logging/registration/filter/CorrelationIdFilter.java
@@ -6,34 +6,33 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.UUID;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-import java.io.IOException;
-import java.util.UUID;
-
 @Component
 public class CorrelationIdFilter implements Filter {
 
-    private static final String CORRELATION_ID_HEADER_NAME = "X-Correlation-ID";
-    private static final String CORRELATION_ID_MDC_KEY = "traceId";
+  private static final String CORRELATION_ID_HEADER_NAME = "X-Correlation-ID";
+  private static final String CORRELATION_ID_MDC_KEY = "traceId";
 
-    @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
-            throws IOException, ServletException {
-        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
-        String correlationId = httpServletRequest.getHeader(CORRELATION_ID_HEADER_NAME);
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+    HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+    String correlationId = httpServletRequest.getHeader(CORRELATION_ID_HEADER_NAME);
 
-        if (!StringUtils.hasText(correlationId)) {
-            correlationId = UUID.randomUUID().toString();
-        }
-
-        MDC.put(CORRELATION_ID_MDC_KEY, correlationId);
-        try {
-            chain.doFilter(request, response);
-        } finally {
-            MDC.remove(CORRELATION_ID_MDC_KEY);
-        }
+    if (!StringUtils.hasText(correlationId)) {
+      correlationId = UUID.randomUUID().toString();
     }
+
+    MDC.put(CORRELATION_ID_MDC_KEY, correlationId);
+    try {
+      chain.doFilter(request, response);
+    } finally {
+      MDC.remove(CORRELATION_ID_MDC_KEY);
+    }
+  }
 }

--- a/src/test/java/com/deepak/registration/RegistrationApplicationTests.java
+++ b/src/test/java/com/deepak/registration/RegistrationApplicationTests.java
@@ -3,6 +3,4 @@ package com.deepak.registration;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class RegistrationApplicationTests {
-
-}
+class RegistrationApplicationTests {}

--- a/src/test/java/com/deepak/registration/security/TokenProviderTest.java
+++ b/src/test/java/com/deepak/registration/security/TokenProviderTest.java
@@ -1,0 +1,56 @@
+package com.deepak.registration.security;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseCookie;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class TokenProviderTest {
+
+  private TokenProvider tokenProvider;
+
+  @BeforeEach
+  void setUp() {
+    tokenProvider = new TokenProvider();
+    // Manually set the fields that would be injected by @Value
+    ReflectionTestUtils.setField(tokenProvider, "jwtSecret", "test-secret");
+    ReflectionTestUtils.setField(tokenProvider, "accessTokenExpirationMs", 1000L);
+    ReflectionTestUtils.setField(tokenProvider, "refreshTokenExpirationMs", 2000L);
+    ReflectionTestUtils.setField(tokenProvider, "cookieDomain", "localhost");
+    ReflectionTestUtils.setField(tokenProvider, "cookieSecure", false);
+  }
+
+  @Test
+  void testGenerateAccessTokenCookie_HttpOnlyFalse() {
+    // Setup: Provide necessary values for @Value fields
+    // Using ReflectionTestUtils from Spring Test module
+    ReflectionTestUtils.setField(tokenProvider, "jwtSecret", "test-secret-for-access");
+    ReflectionTestUtils.setField(tokenProvider, "accessTokenExpirationMs", 3600000L); // 1 hour
+    ReflectionTestUtils.setField(tokenProvider, "cookieDomain", "localhost");
+    ReflectionTestUtils.setField(tokenProvider, "cookieSecure", false);
+
+    ResponseCookie accessTokenCookie = tokenProvider.generateAccessTokenCookie("dummyAccessToken");
+    assertFalse(accessTokenCookie.isHttpOnly(), "Access token cookie should not be HttpOnly");
+    assertFalse(
+        accessTokenCookie.toString().contains("HttpOnly"),
+        "Access token cookie string should not contain HttpOnly");
+  }
+
+  @Test
+  void testGenerateRefreshTokenCookie_HttpOnlyFalse() {
+    // Setup: Provide necessary values for @Value fields
+    ReflectionTestUtils.setField(tokenProvider, "jwtSecret", "test-secret-for-refresh");
+    ReflectionTestUtils.setField(tokenProvider, "refreshTokenExpirationMs", 86400000L); // 1 day
+    ReflectionTestUtils.setField(tokenProvider, "cookieDomain", "localhost");
+    ReflectionTestUtils.setField(tokenProvider, "cookieSecure", false);
+
+    ResponseCookie refreshTokenCookie =
+        tokenProvider.generateRefreshTokenCookie("dummyRefreshToken");
+    assertFalse(refreshTokenCookie.isHttpOnly(), "Refresh token cookie should not be HttpOnly");
+    assertFalse(
+        refreshTokenCookie.toString().contains("HttpOnly"),
+        "Refresh token cookie string should not contain HttpOnly");
+  }
+}


### PR DESCRIPTION
The HttpOnly attribute has been set to false for access tokens, refresh tokens, and cookies used for clearing these tokens. This change allows client-side scripts to access these cookies if necessary.

The following methods in `TokenProvider.java` were modified:
- `generateAccessTokenCookie`
- `generateRefreshTokenCookie`
- `generateClearAccessTokenCookie`
- `generateClearRefreshTokenCookie`

Additionally, new unit tests have been added in `TokenProviderTest.java` to verify that the `HttpOnly` attribute is correctly set to `false` for the generated cookies. These tests confirm the intended behavior and protect against future regressions.